### PR TITLE
Directive based on local flex direction

### DIFF
--- a/application/src/app/app.component.html
+++ b/application/src/app/app.component.html
@@ -1,11 +1,11 @@
-<div class="main-header">
+<div appLocalFlexDirection class="main-header">
     <div>
         <h1>
             <app-svg-icon [icon]="SvgIcon.mainLogo"></app-svg-icon>
             <span>{{ appName }}</span>
         </h1>
     </div>
-    <div class="header-menu">
+    <div appLocalFlexDirection class="header-menu">
         <app-language-picker></app-language-picker>
         <h3>
             <app-login-button></app-login-button>

--- a/application/src/app/app.component.scss
+++ b/application/src/app/app.component.scss
@@ -1,8 +1,6 @@
 @import 'src/assets/css/variables';
 
 .main-header {
-    display: flex;
-    flex-direction: row;
     justify-content: space-between;
     align-items: center;
     border-bottom: solid 1px;
@@ -11,12 +9,12 @@
     padding: 0.5rem 1rem;
 
     .header-menu {
-        display: inline-flex;
-        flex-direction: row;
         align-items: center;
+        margin: 0 -0.25rem;
+        overflow-x: hidden;
 
-        & > *:not(:last-child) {
-            margin-right: 0.5rem;
+        & > * {
+            margin: 0 0.25rem;
         }
     }
 }

--- a/application/src/app/app.module.ts
+++ b/application/src/app/app.module.ts
@@ -21,6 +21,7 @@ import { PrivacyPolicyPopupComponent } from './components/preferences/privacy-po
 import { SvgIconComponent } from './components/utils/svg-icon/svg-icon.component';
 import { AuthModule } from '@auth0/auth0-angular';
 import { LoginButtonComponent } from './components/auth/login-button/login-button.component';
+import { LocalFlexDirectionDirective } from './directives/local-flex-direction.directive';
 
 // Use github documentation for setup:
 // https://github.com/ngx-translate/core
@@ -37,7 +38,8 @@ export function HttpLoaderFactory(http: HttpClient) {
     PreferencePopupComponent,
     PrivacyPolicyPopupComponent,
     SvgIconComponent,
-    LoginButtonComponent
+    LoginButtonComponent,
+    LocalFlexDirectionDirective
   ],
   imports: [
     BrowserModule,

--- a/application/src/app/directives/local-flex-direction.directive.spec.ts
+++ b/application/src/app/directives/local-flex-direction.directive.spec.ts
@@ -1,0 +1,8 @@
+import { LocalFlexDirectionDirective } from './local-flex-direction.directive';
+
+describe('LocalFlexDirectionDirective', () => {
+  it('should create an instance', () => {
+    const directive = new LocalFlexDirectionDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/application/src/app/directives/local-flex-direction.directive.spec.ts
+++ b/application/src/app/directives/local-flex-direction.directive.spec.ts
@@ -1,8 +1,47 @@
+import { Component } from '@angular/core';
 import { LocalFlexDirectionDirective } from './local-flex-direction.directive';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BehaviorSubject } from 'rxjs';
+import { TranslateService } from '@ngx-translate/core';
 
 describe('LocalFlexDirectionDirective', () => {
-  it('should create an instance', () => {
-    const directive = new LocalFlexDirectionDirective();
-    expect(directive).toBeTruthy();
+  @Component({
+    template: '<div appLocalFlexDirection></div>'
+  })
+  class Wrapper {}
+
+  const translateServiceMock = {
+    onLangChange: new BehaviorSubject({ 
+      translations: { "language:direction": "vertical" }
+    })
+  };
+
+  let fixture: ComponentFixture<Wrapper>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      providers: [
+        { provide: TranslateService, useValue: translateServiceMock },
+      ],
+      declarations: [
+        Wrapper,
+        LocalFlexDirectionDirective
+      ]
+    }).compileComponents();
+    fixture = TestBed.createComponent(Wrapper);
+    fixture.detectChanges();
+  });
+
+  it('should have the default class when initilised', () => {
+    expect(fixture.nativeElement.querySelector('div').classList).toContain('vertical');
+  });
+
+  it('should have updated the class when language direction has changed', () => {
+    translateServiceMock.onLangChange.next({
+      translations: { "language:direction": "horizontal" }
+    });
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('div').classList).not.toContain('vertical');
+    expect(fixture.nativeElement.querySelector('div').classList).toContain('horizontal');
   });
 });

--- a/application/src/app/directives/local-flex-direction.directive.ts
+++ b/application/src/app/directives/local-flex-direction.directive.ts
@@ -1,10 +1,28 @@
-import { Directive } from '@angular/core';
+import { Directive, HostBinding, OnDestroy, OnInit } from '@angular/core';
+import { LangChangeEvent, TranslateService } from '@ngx-translate/core';
+import { Subscription } from 'rxjs';
 
 @Directive({
   selector: '[appLocalFlexDirection]'
 })
-export class LocalFlexDirectionDirective {
+export class LocalFlexDirectionDirective implements OnInit, OnDestroy {
 
-  constructor() { }
+  private sub: Subscription;
+  
+  @HostBinding('class') flexClass = 'left-to-right';
+
+  constructor(
+    private translations: TranslateService
+  ) {}
+
+  ngOnInit(): void {
+    this.sub = this.translations.onLangChange.subscribe((event: LangChangeEvent) => {
+      this.flexClass = event.translations['language:direction'];
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.sub.unsubscribe();
+  }
 
 }

--- a/application/src/app/directives/local-flex-direction.directive.ts
+++ b/application/src/app/directives/local-flex-direction.directive.ts
@@ -1,0 +1,10 @@
+import { Directive } from '@angular/core';
+
+@Directive({
+  selector: '[appLocalFlexDirection]'
+})
+export class LocalFlexDirectionDirective {
+
+  constructor() { }
+
+}

--- a/application/src/assets/config/translation/en.json
+++ b/application/src/assets/config/translation/en.json
@@ -1,4 +1,5 @@
 {
+    "language:direction": "left-to-right",
     "button:select-all": "Select all",
     "button:only-selected": "Only my choices",
     "welcome": "Welcome!",

--- a/application/src/assets/config/translation/fr.json
+++ b/application/src/assets/config/translation/fr.json
@@ -1,4 +1,5 @@
 {
+    "language:direction": "right-to-left",
     "button:select-all": "Tout selectionner",
     "button:only-selected": "Seulement ma selection",
     "welcome": "Bienvenu(e)!",

--- a/application/src/assets/css/_flex.scss
+++ b/application/src/assets/css/_flex.scss
@@ -1,0 +1,9 @@
+.left-to-right {
+    display: flex;
+    flex-direction: row;
+}
+
+.right-to-left {
+    display: flex;
+    flex-direction: row-reverse;
+}

--- a/application/src/assets/css/index.scss
+++ b/application/src/assets/css/index.scss
@@ -1,4 +1,5 @@
 @import './buttons';
+@import './flex';
 @import './fonts';
 @import './variables';
 @import './web-page';


### PR DESCRIPTION
The following code creates a directive `appLocalFlexDirection`. It allows an HTML tag to be displayed as a `flex` and defines its `flex-direction` based on the language key `"language:direction": "right-to-left" | "left-to-right"`.